### PR TITLE
fix: llvm_ir_visitor derived from std::enable_shared_from_this

### DIFF
--- a/include/llvm_ir_visitor.hpp
+++ b/include/llvm_ir_visitor.hpp
@@ -17,7 +17,10 @@
 #include <llvm/IR/Verifier.h>
 #include <memory>
 
-class llvm_ir_visitor : public ir_visitor, public collector {
+class llvm_ir_visitor : public ir_visitor,
+                        public collector,
+                        public std::enable_shared_from_this<llvm_ir_visitor>
+{
 public:
   llvm_ir_visitor() : Builder(TheContext), NamedValues() {
     TheModule = std::make_unique<llvm::Module>("my cool jit", TheContext);
@@ -41,7 +44,7 @@ public:
       NamedValues[std::string(Arg.getName())] = &Arg;
     }
 
-    auto visitor = std::make_shared<llvm_ir_visitor>();
+    auto visitor = shared_from_this();
     def->body()->accept(visitor);
     auto statements = visitor->collect();
     if (llvm::Value *RetVal =
@@ -65,7 +68,7 @@ public:
     values.push_back(std::make_shared<llvm::Value *>(V));
   }
   virtual void visit(ast::number *n) {
-    auto v = llvm::ConstantFP::get(TheContext, llvm::APFloat((float)n->v()));
+    auto v = llvm::ConstantFP::get(TheContext, llvm::APFloat((double)n->v()));
     values.push_back(std::make_shared<llvm::Value *>(v));
   }
   virtual void visit(ast::type *) {}
@@ -102,11 +105,10 @@ public:
       return;
 
     std::vector<llvm::Value *> ArgsV;
-    for (auto &arg : Args) {
-      auto visitor = std::make_shared<llvm_ir_visitor>();
-      arg.get().accept(visitor);
-      auto exprs = visitor->collect();
-      auto r = exprs.front().get();
+    for (ast::node& arg : Args) {
+      auto visitor = shared_from_this();
+      arg.accept(visitor);
+      auto r = visitor->collect().back().get();
       ArgsV.push_back(*r);
     }
 

--- a/test/ast.cpp
+++ b/test/ast.cpp
@@ -92,9 +92,8 @@ TEST(ast, should_able_to_parse_the_func_call) {
   tu.pop_front();
   tu.front()->accept(visitor);
   auto inst = visitor->collect();
-  ASSERT_THAT(inst.size(), testing::Eq(2));
-  inst.pop_front();
-  llvm::Value **v = inst.front().get();
+  ASSERT_THAT(inst.size(), testing::Eq(3));
+  llvm::Value **v = inst.back().get();
   ASSERT_TRUE(llvm::isa<llvm::CallInst>(**v));
 
   auto call = llvm::dyn_cast<llvm::CallInst>(*v);
@@ -103,7 +102,7 @@ TEST(ast, should_able_to_parse_the_func_call) {
   ASSERT_TRUE(llvm::isa<llvm::ConstantFP>(*argsIterator));
   llvm::APFloat arg =
       llvm::dyn_cast<llvm::ConstantFP>(*argsIterator)->getValueAPF();
-  ASSERT_THAT(arg.convertToFloat(), testing::FloatEq(1.0f));
+  ASSERT_THAT(arg.convertToDouble(), testing::DoubleEq(1.0f));
 }
 
 TEST(ast, should_able_to_parse_the_double_parameter_func_call) {
@@ -118,9 +117,8 @@ TEST(ast, should_able_to_parse_the_double_parameter_func_call) {
   tu.pop_front();
   tu.front()->accept(visitor);
   auto inst = visitor->collect();
-  ASSERT_THAT(inst.size(), testing::Eq(2));
-  inst.pop_front();
-  llvm::Value **v = inst.front().get();
+  ASSERT_THAT(inst.size(), testing::Eq(4));
+  llvm::Value **v = inst.back().get();
   ASSERT_TRUE(llvm::isa<llvm::CallInst>(**v));
 
   auto call = llvm::dyn_cast<llvm::CallInst>(*v);


### PR DESCRIPTION
1. make sure all nodes accept the unique only llvm_ir_visitor
2. must cast the float number to double because
   llvm::Type::getDoubleTy() is used to construct FunctionType
3. replace auto in for-loop with for (ReferredType& foo :
   std::reference_wrapper<ReferredType>) to avoid calling get()